### PR TITLE
Fix manifest.f4m generator

### DIFF
--- a/mp4frag/mp4frag.cc
+++ b/mp4frag/mp4frag.cc
@@ -209,7 +209,7 @@ void get_manifest(std::streambuf* sb, const std::vector< boost::shared_ptr<Media
     for ( unsigned imedia = 0; imedia < medialist.size(); ++imedia ) {
         const boost::shared_ptr<Media>& fi = medialist[imedia];
         manifest_out <<  
-          "<media streamId=\"" << video_id << "\" url=\"" << imedia << "/\" bootstrapinfoId=\"" << info << "\" "
+          "<media streamId=\"" << video_id << "\" url=\"" << imedia << "/\" bootstrapInfoId=\"" << info << "\" "
           "bitrate=\"" << int(fi->mapping->size() / fi->duration / 10000 * 8) * 10000 << "\" "
           " />\n";
     }


### PR DESCRIPTION
Change attribute "bootstrapinfoId" in "media" node to "bootstrapInfoId", because OSMF 2.0 doesn't accept "bootstrapinfoId"

```
$ diff ./manifest_good.f4m ./manifest_bad.f4m
7,9c7,9
< <media streamId="some_video" url="0/" bootstrapInfoId="bootstrap" bitrate="9290000"  />
< <media streamId="some_video" url="1/" bootstrapInfoId="bootstrap" bitrate="5560000"  />
< <media streamId="some_video" url="2/" bootstrapInfoId="bootstrap" bitrate="2240000"  />

---
> <media streamId="some_video" url="0/" bootstrapinfoId="bootstrap" bitrate="9290000"  />
> <media streamId="some_video" url="1/" bootstrapinfoId="bootstrap" bitrate="5560000"  />
> <media streamId="some_video" url="2/" bootstrapinfoId="bootstrap" bitrate="2240000"  />
```

Demo
Bad: http://osmf.org/dev/2.0gm/StrobeMediaPlayback.html?src=https://s3.amazonaws.com/hds_test/bunny_hds/manifest_bad.f4m
Good: http://osmf.org/dev/2.0gm/StrobeMediaPlayback.html?src=https://s3.amazonaws.com/hds_test/bunny_hds/manifest_good.f4m
